### PR TITLE
Add auto-create for junior partners

### DIFF
--- a/migration_allow_partner_on_behalf.sql
+++ b/migration_allow_partner_on_behalf.sql
@@ -1,7 +1,12 @@
 -- Migration: Allow partners to insert protections on behalf of other partners
 -- Issue: https://github.com/rajeshl8/the10Kpromise_app/issues/1
--- Description: Updates RLS policy to enable partners to log protections for other partners
--- Date: 2026-01-19
+-- Description: Updates RLS policies to enable partners to log protections for other partners
+--              and create junior partner records
+-- Date: 2026-01-27
+
+-- ========================================
+-- 1. Update PROTECTIONS insert policy
+-- ========================================
 
 -- Drop existing insert policy for protections
 DROP POLICY IF EXISTS prot_insert ON public.protections;
@@ -27,4 +32,33 @@ FOR INSERT WITH CHECK (
 
 -- Note: The SELECT policy remains unchanged, so partners can only view their own protections
 -- This ensures privacy while allowing collaboration through the "on behalf of" feature
+
+-- ========================================
+-- 2. Update PARTNERS insert policy
+-- ========================================
+
+-- Drop existing insert policy for partners
+DROP POLICY IF EXISTS partners_insert ON public.partners;
+
+-- Create new policy that allows:
+-- 1. Admins to insert anyone
+-- 2. Partners to insert themselves (original behavior)
+-- 3. Partners to create other partners (for junior partners)
+CREATE POLICY partners_insert ON public.partners
+FOR INSERT WITH CHECK (
+  -- Allow admins to insert anyone
+  public.is_admin()
+  OR
+  -- Allow partners to insert themselves
+  auth.uid() = user_id
+  OR
+  -- Allow authenticated partners to create junior partners
+  -- (user_id will be different from auth.uid() for juniors)
+  EXISTS (
+    SELECT 1 FROM public.partners WHERE user_id = auth.uid()
+  )
+);
+
+-- This allows senior partners to create junior partner records
+-- Junior partners will have placeholder user_ids and won't have login access
 

--- a/src/components/AddProtectionDialog.tsx
+++ b/src/components/AddProtectionDialog.tsx
@@ -29,27 +29,60 @@ export default function AddProtectionDialog({
     let targetPartnerId = partner.id
     let targetPartnerUserId = partner.user_id
     
-    // If entering on behalf of another partner, look them up first
+    // If entering on behalf of another partner, look them up or create them
     if (isOnBehalfOf) {
       if (!otherPartnerCode.trim()) {
         setLookupError('Partner Code is required')
         return
       }
       
+      // Try to find existing partner
       const { data: otherPartner, error: lookupErr } = await supabase
         .from('partners')
         .select('id, user_id')
         .eq('hgi_partner_id', otherPartnerCode.trim())
         .single()
       
-      if (lookupErr || !otherPartner) {
-        setLookupError('Partner not found. Please check the Partner Code.')
-        return
+      if (otherPartner) {
+        // Partner exists, use their details
+        targetPartnerId = otherPartner.id
+        targetPartnerUserId = otherPartner.user_id
+        setLookupError('')
+      } else {
+        // Partner not found - create them as a junior partner
+        if (!otherPartnerName.trim()) {
+          setLookupError('Partner not found. Please provide Partner Name to create a new entry.')
+          return
+        }
+        
+        // Parse name (simple split by space)
+        const nameParts = otherPartnerName.trim().split(' ')
+        const firstName = nameParts[0]
+        const lastName = nameParts.slice(1).join(' ') || firstName
+        
+        // Create new junior partner with placeholder user_id
+        const { data: newPartner, error: createErr } = await supabase
+          .from('partners')
+          .insert({
+            user_id: crypto.randomUUID(), // Placeholder user_id (not linked to auth)
+            email: `${otherPartnerCode.toLowerCase()}@junior.placeholder`,
+            first_name: firstName,
+            last_name: lastName,
+            hgi_partner_id: otherPartnerCode.trim(),
+            personal_target: 100
+          })
+          .select('id, user_id')
+          .single()
+        
+        if (createErr || !newPartner) {
+          setLookupError('Failed to create partner: ' + (createErr?.message || 'Unknown error'))
+          return
+        }
+        
+        targetPartnerId = newPartner.id
+        targetPartnerUserId = newPartner.user_id
+        setLookupError('')
       }
-      
-      targetPartnerId = otherPartner.id
-      targetPartnerUserId = otherPartner.user_id
-      setLookupError('')
     }
     
     startTransition(async () => {


### PR DESCRIPTION
- Junior partners are auto-created if not found by HGI Partner ID
- Juniors get placeholder user_id (not linked to auth)
- Juniors appear on leaderboard but cannot login
- Updated RLS policy to allow partner creation by authenticated partners
- Added better error messaging for missing partner name